### PR TITLE
change the required flag to require letters in any order or position

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ mandatory agrument:
 
 optional arguments:
 
-    -h, --help     : show help message and exit 
-    -m, --min      : Minimum amount of letters in anagram
-    -s, --starts   : Generates words starting with this letter
-    -e, --ends     : Generates words ending with this letter
-    -r, --required : Generates words that must have this letter or letters
+    -h, --help      : show help message and exit 
+    -m, --min       : Minimum amount of letters in anagram
+    -s, --starts    : Generates words starting with this letter
+    -e, --ends      : Generates words ending with this letter
+    -r, --required  : Generates words that must have this letter or letters
+    --limit         : The maximum number of words you want to see (Default: 5)
+    -u, --unordered : Leave the output in alphabetical order
 
 example:
 
@@ -23,8 +25,8 @@ example:
     
     reequip
     requite
-    roque
     roquet
+    roque
 
 anagram-gui.py
 ==============

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ optional arguments:
     -s, --starts    : Generates words starting with this letter
     -e, --ends      : Generates words ending with this letter
     -r, --required  : Generates words that must have this letter or letters
-    --limit         : The maximum number of words you want to see (Default: 5)
+    --limit         : The maximum number of words you want to see (Default: unlimited)
     -u, --unordered : Leave the output in alphabetical order
 
 example:

--- a/anagram.py
+++ b/anagram.py
@@ -1,5 +1,6 @@
 import argparse
 
+
 def anagramchk(word,chkword):
     for letter in word:
         if letter in chkword:
@@ -8,7 +9,7 @@ def anagramchk(word,chkword):
             return 0
     return 1
 
-def hasAllRequired(word,required):
+def has_all_required(word,required):
     for letter in required:
         if letter not in word:
             return False
@@ -42,7 +43,7 @@ def solve(opts):
 
             if opts['required']:
                 for word in words:
-                    if not hasAllRequired(word, opts['required']):
+                    if not has_all_required(word, opts['required']):
                         words.remove(word)
 
             if not opts['unordered']:
@@ -63,7 +64,7 @@ parser.add_argument('-s','--starts', help='Generates words starting with this le
 parser.add_argument('-e','--ends', help='Generates words ending with this letter', required=False)
 parser.add_argument('-r','--required', help='Generates words that must have this letter or letters', required=False)
 parser.add_argument('-u', '--unordered', action='store_true', help='Leave the output in alphabetical order', required=False)
-parser.add_argument('--limit', help='The maximum number of words you want to see', default=5, required=False)
+parser.add_argument('--limit', help='The maximum number of words you want to see', default=0, required=False)
 args = vars(parser.parse_args())
 
 solve(args)

--- a/anagram.py
+++ b/anagram.py
@@ -1,6 +1,5 @@
 import argparse
 
-
 def anagramchk(word,chkword):
     for letter in word:
         if letter in chkword:
@@ -9,44 +8,62 @@ def anagramchk(word,chkword):
             return 0
     return 1
 
+def hasAllRequired(word,required):
+    for letter in required:
+        if letter not in word:
+            return False
+        word = word.replace(letter, '', 1)
+    return True
+
+def solve(opts):
+    f=open('wordlist.txt', 'r')
+    words = []
+
+    for line in f:
+        line=line.strip()
+
+        if anagramchk(line,opts['letters']):
+            words.append(line)
+
+            if opts['min']:
+                for word in words:
+                    if not len(word)>=int(opts['min']):
+                        words.remove(word)
+                
+            if opts['starts']:
+                for word in words:
+                    if word[0] != opts['starts']:
+                        words.remove(word)
+            
+            if opts['ends']:
+                for word in words:
+                    if word[-1] != opts['ends']:
+                        words.remove(word)
+
+            if opts['required']:
+                for word in words:
+                    if not hasAllRequired(word, opts['required']):
+                        words.remove(word)
+
+            if not opts['unordered']:
+                words.sort(key=len, reverse=True)
+
+            if opts['limit']:
+                words=words[:int(opts['limit'])]
+        
+    for word in words:
+        print(word)
+
+    f.close()
+
 parser = argparse.ArgumentParser(description='Anagram generator with several options to control the generated words')
 parser.add_argument('-l','--letters', help='Letters provided to generate an anagram', required=True)
 parser.add_argument('-m','--min', help='Minimum amount of letters in anagram', required=False)
 parser.add_argument('-s','--starts', help='Generates words starting with this letter', required=False)
 parser.add_argument('-e','--ends', help='Generates words ending with this letter', required=False)
 parser.add_argument('-r','--required', help='Generates words that must have this letter or letters', required=False)
+parser.add_argument('-u', '--unordered', action='store_true', help='Leave the output in alphabetical order', required=False)
+parser.add_argument('--limit', help='The maximum number of words you want to see', default=5, required=False)
 args = vars(parser.parse_args())
 
-f=open('wordlist.txt', 'r')
-words = []
-
-for line in f:
-    line=line.strip()
-
-    if anagramchk(line,args['letters']):
-        words.append(line)
-
-        if args['min']:
-            for word in words:
-                if not len(word)>=int(args['min']):
-                    words.remove(word)
-            
-        if args['starts']:
-            for word in words:
-                if word[0] != args['starts']:
-                    words.remove(word)
-        
-        if args['ends']:
-            for word in words:
-                if word[-1] != args['ends']:
-                    words.remove(word)
-
-        if args['required']:
-            for word in words:
-                if args['required'] not in word:
-                    words.remove(word)
-    
-for word in words:
-    print word
-
-f.close()
+solve(args)


### PR DESCRIPTION
`-t ehllo -r lle` would previously not return `hello` because it required the full pattern to be in order, this makes it so it merely needs to have all of those letters in place

this also adds sorting by word length with the optional `-u --unordered` to display in the original order
this also adds `--limit` to only return the top X words. Defaults to unlimited
